### PR TITLE
Infix operators + verbose syntax

### DIFF
--- a/src/OpenGames/Examples/Bimatrix.hs
+++ b/src/OpenGames/Examples/Bimatrix.hs
@@ -26,12 +26,29 @@ generateGame "matchingPenniesTH" []
                         [Line [] [] [|reindex const (decision "player1" [Heads, Tails])|] ["x"] [[|matchingPenniesMatrix1 x y|]],
                          Line [] [] [|reindex const (decision "player2" [Heads, Tails])|] ["y"] [[|matchingPenniesMatrix2 x y|]]]
 
+--
 -- Using Quasiquotes
-matchingPennies = [game|
-   || =>>
-  x | matchingPenniesMatrix1 x y <- reindex const (decision "player1" [Heads, Tails]) -< | ;
-  y | matchingPenniesMatrix2 x y <- reindex const (decision "player2" [Heads, Tails]) -< | ;
-   <<= ||
+matchingPennies = [opengame|
+
+    inputs : ;
+    feedback : ;
+    :-----------------------------:
+
+    inputs : ;
+    feedback : ;
+    operation : reindex const (decision "player1" [Heads, Tails]) ;
+    returns : matchingPenniesMatrix1 x y ;
+    outputs : x ;
+
+    inputs : ;
+    feedback : ;
+    operation : reindex const (decision "player2" [Heads, Tails]) ;
+    returns : matchingPenniesMatrix2 x y ;
+    outputs : y ;
+
+    :-----------------------------:
+    returns : ;
+    outputs : ;
 |]
 
 matchingPenniesEquilibrium = equilibrium matchingPennies trivialContext

--- a/src/OpenGames/Examples/Bimatrix.hs
+++ b/src/OpenGames/Examples/Bimatrix.hs
@@ -30,25 +30,14 @@ generateGame "matchingPenniesTH" []
 -- Using Quasiquotes
 matchingPennies = [opengame|
 
-    inputs : ;
-    feedback : ;
-    :-----------------------------:
-
-    inputs : ;
-    feedback : ;
     operation : reindex const (decision "player1" [Heads, Tails]) ;
     returns : matchingPenniesMatrix1 x y ;
     outputs : x ;
 
-    inputs : ;
-    feedback : ;
     operation : reindex const (decision "player2" [Heads, Tails]) ;
     returns : matchingPenniesMatrix2 x y ;
     outputs : y ;
 
-    :-----------------------------:
-    returns : ;
-    outputs : ;
 |]
 
 matchingPenniesEquilibrium = equilibrium matchingPennies trivialContext

--- a/src/OpenGames/Examples/LemonMarket.hs
+++ b/src/OpenGames/Examples/LemonMarket.hs
@@ -39,7 +39,7 @@ lemonMarket = [game|
   || =>>
   quality | <- nature (fromFreqs [(Good, 1), (Bad, 4)]) -< | ;
   price   | lemonUtilitySeller quality price buy <- decision "seller" [Low, High] -< | quality ;
-  buy     | lemonUtilityBuyer quality price buy <- decision "buyer" [Buy, NotBuy] -< | price ;
+  buy     | (price + price) <- decision "buyer" [Buy, NotBuy] -< | price ;
   <<= ||
 |]
 

--- a/src/OpenGames/Examples/LemonMarket.hs
+++ b/src/OpenGames/Examples/LemonMarket.hs
@@ -39,7 +39,7 @@ lemonMarket = [game|
   || =>>
   quality | <- nature (fromFreqs [(Good, 1), (Bad, 4)]) -< | ;
   price   | lemonUtilitySeller quality price buy <- decision "seller" [Low, High] -< | quality ;
-  buy     | (price + price) <- decision "buyer" [Buy, NotBuy] -< | price ;
+  buy     | lemonUtilityBuyer quality price buy <- decision "buyer" [Buy, NotBuy] -< | price ;
   <<= ||
 |]
 

--- a/src/OpenGames/Examples/RepetitionTest.hs
+++ b/src/OpenGames/Examples/RepetitionTest.hs
@@ -30,16 +30,19 @@ stagePDPayoffs Defect Defect = (1, 1)
 repetitionTestDiscountFactor :: Double
 repetitionTestDiscountFactor = 0.1
 
--- stagePDQQ = [game| titForTatState, grimTriggerState || payoff1, payoff2 =>>
+-- stagePDQQ = [game|
+--   payoff1, payoff2 || titForTatState, grimTriggerState =>>
 --
---       move1 | payoff1 <- pureDecision [Cooperate, Defect] -< | titForTatState ;
---       move2 | payoff2 <- pureDecision [Cooperate, Defect] -< | grimTriggerState ;
---       move1, move2 | continuation1, continuation2
---          <- fromFunctions id (\(move1, move2, continuation1, continuation2) ->
---               let (u1, u2) = stagePDPayoffs move1 move2 in (u1 + repetitionTestDiscountFactor*continuation1,
---                                                             u2 + repetitionTestDiscountFactor*continuation2))
---          -< | payoff1, payoff2
---   <<= (continuation1, continuation2) || (stagePDTitForTatTransition titForTatState move2, stagePDGrimTriggerTransition grimTriggerState move1), (move1, move2) |]
+--   move1 | payoff1 <- pureDecision [Cooperate, Defect] -< | titForTatState ;
+--   move2 | payoff2 <- pureDecision [Cooperate, Defect] -< | grimTriggerState ;
+--         | move1, move2 , continuation1, continuation2
+--           <- fromFunctions id (\(move1, move2, continuation1, continuation2) ->
+--                let (u1, u2) = stagePDPayoffs move1 move2 in (u1 + repetitionTestDiscountFactor*continuation1,
+--                                                              u2 + repetitionTestDiscountFactor*continuation2))
+--           -< | payoff1, payoff2 ;
+--   <<=  (continuation1, continuation2)
+--   || (stagePDTitForTatTransition titForTatState move2, stagePDGrimTriggerTransition grimTriggerState move1), (move1, move2)
+--   |]
 
 -- generateGame "stagePDTH" [] $  GBlock ["titForTatState", "grimTriggerState"] ["payoff1", "payoff2"]
 --   [Line [param "titForTatState"]   [] [|pureDecision [Cooperate, Defect]|] ["move1"] [[|payoff1|]],

--- a/src/OpenGames/Preprocessor/Compile.hs
+++ b/src/OpenGames/Preprocessor/Compile.hs
@@ -43,6 +43,12 @@ compileLambda (Do sm) = DoE (map toStatement sm)
 compileLambda (Tuple f s r) = TupE (map (compileLambda) (f : s : r))
 compileLambda (Range range) = ArithSeqE (compileRange range)
 compileLambda (IfThenElse prd thn els) = CondE (compileLambda prd) (compileLambda thn) (compileLambda els)
+compileLambda (Ifix op left right) = InfixE (Just $ compileLambda left)
+                                            (VarE $ mkName op)
+                                            (Just $ compileLambda right)
+
+compileLambda (PFix "-" arg) = AppE (VarE (mkName "negate")) (compileLambda arg)
+compileLambda (PFix op arg) = error $ "unsupported prefix operator: " ++ op
 
 compilePattern :: Pattern -> Pat
 compilePattern (PLit (LInt i)) = LitP $ IntegerL i

--- a/src/OpenGames/Preprocessor/Compile.hs
+++ b/src/OpenGames/Preprocessor/Compile.hs
@@ -33,7 +33,7 @@ compileLambda (Lit l) = compileLiteral l
 compileLambda (Var s) | isUpper (head s)  = ConE (mkName s)
                       | otherwise         = VarE (mkName s)
 compileLambda (App f a) = AppE (compileLambda f) (compileLambda a)
-compileLambda (Lam var body) = LamE [VarP (mkName var)] (compileLambda body)
+compileLambda (Lam pat body) = LamE [compilePattern pat] (compileLambda body)
 compileLambda (LList ls) = ListE $ map compileLambda ls
 compileLambda (Do sm) = DoE (map toStatement sm)
   where
@@ -49,6 +49,10 @@ compileLambda (Ifix op left right) = InfixE (Just $ compileLambda left)
 
 compileLambda (PFix "-" arg) = AppE (VarE (mkName "negate")) (compileLambda arg)
 compileLambda (PFix op arg) = error $ "unsupported prefix operator: " ++ op
+compileLambda (LLet pat val body) = LetE [ValD (compilePattern pat)
+                                               (NormalB (compileLambda val))
+                                               []]
+                                         (compileLambda body)
 
 compilePattern :: Pattern -> Pat
 compilePattern (PLit (LInt i)) = LitP $ IntegerL i
@@ -101,6 +105,19 @@ parseLambdaAsExp input = case parseLambda input of
 game :: QuasiQuoter
 game = QuasiQuoter
      { quoteExp  = parseLambdaAsExp . dropWhile isSpace
+     , quotePat  = error "expected expr"
+     , quoteType = error "expected expr"
+     , quoteDec  = error "expected expr"
+     }
+
+parseVerboseGame :: String -> Q Exp
+parseVerboseGame input = case parseVerbose input of
+                           Left err ->  error (show err)
+                           Right v ->  (interpretOpenGame $ compileBlock $ compileAST $ convertGame v)
+
+opengame :: QuasiQuoter
+opengame = QuasiQuoter
+     { quoteExp  = parseVerboseGame . dropWhile isSpace
      , quotePat  = error "expected expr"
      , quoteType = error "expected expr"
      , quoteDec  = error "expected expr"

--- a/src/OpenGames/Preprocessor/Lambda.hs
+++ b/src/OpenGames/Preprocessor/Lambda.hs
@@ -225,7 +225,7 @@ bracketed =
 
 
 term :: Parser Lambda
-term =  parens (try parseTuple <|> infixParser expr <|> expr)
+term =  parens (try parseTuple <|> expr)
     <|> ifExp
     <|> lambda
     <|> variable
@@ -234,10 +234,13 @@ term =  parens (try parseTuple <|> infixParser expr <|> expr)
     <|> brackets bracketed
     <|> doNotation
 
-expr :: Parser Lambda
-expr = do
+appl :: Parser Lambda
+appl = do
   es <- many1 term
   return (foldl1 App es)
+
+expr :: Parser Lambda
+expr =  infixParser appl
 
 data ParsedLine p e = MkParsedLine { covOut :: [p]
                                    , conIn :: [e]

--- a/src/OpenGames/Preprocessor/Parser.hs
+++ b/src/OpenGames/Preprocessor/Parser.hs
@@ -25,3 +25,7 @@ realParser =  parseBlock parsePattern expr (parseLine parsePattern expr) <* eof
 
 parseLambda :: String -> Either ParseError (GameAST Pattern Lambda)
 parseLambda = parse realParser "realParser"
+
+parseVerbose :: String -> Either ParseError (GameAST Pattern Lambda)
+parseVerbose = parse (parseVerboseSyntax parsePattern expr (parseVerboseLine parsePattern expr)) "verbose parser"
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -64,3 +64,6 @@ packages:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+#
+ghc-options:
+  "$locals": -fwarn-incomplete-patterns


### PR DESCRIPTION
This pull request adds support for a set of predefined operators as well as a draft for a more verbose, but maybe easier to learn, syntax for open games:

```
inputs : a , b, c; 
feedback : f1, f2, f3 ; 
:--------------------:

inputs : d, e, f ; 
feedback : g1, g2, g3 ;
operation : op ;
returns : g1, g2, g3 ;
outputs : d, e, f ;

:--------------------:
returns : f1, f2, f3;
outputs: d, e, f;
```

Everything between `:---:` is a line, the `inputs` and `outputs` outside the `:---:` are the boundaries of the "block".