### PR TITLE
nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ dist-newstyle/
 
 # direnv
 .direnv/
+
+# nix
+result
+result/

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ TSWLatexianTemp*
 .DS_Store
 .stack-work/
 dist-newstyle/
+
+# direnv
+.direnv/

--- a/act/Act/TH/Extractor.hs
+++ b/act/Act/TH/Extractor.hs
@@ -6,12 +6,9 @@ module Act.TH.Extractor (argumentExtractorName, generateExtractMethods) where
 
 import Act.Prelude
 import Act.Utils
-import Data.Data
 import Data.List
 import Language.Haskell.TH.Syntax as TH
 import Syntax.Annotated
-
-deriving instance Data AbiType
 
 -- Given each method in the contract we need to know how to extract the arguments from the
 -- arguments' array. for this we create a partial top-level function which matches

--- a/act/EVM/TH.hs
+++ b/act/EVM/TH.hs
@@ -122,8 +122,7 @@ emptyVM contracts =
         { contracts = Map.fromList (fmap (fmap bytecodeToContract) contracts),
           chainId = 0,
           storage = EmptyStore,
-          origStorage = mempty,
-          sha3Crack = mempty
+          origStorage = mempty
         }
 
     bytecodeToContract :: ByteString -> Contract

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "act": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1685616523,
+        "narHash": "sha256-fERVRwJxxvOSR+JfvcCXOa5GHrGtYkYHB/Ul2d7gLE8=",
+        "owner": "ethereum",
+        "repo": "act",
+        "rev": "52e99daf3121a4e6a6cb28255e862cf8e83cf4cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "repo": "act",
+        "rev": "52e99daf3121a4e6a6cb28255e862cf8e83cf4cd",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -15,6 +35,24 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -35,16 +73,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695360818,
-        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
+        "lastModified": 1684164265,
+        "narHash": "sha256-ZqNSKSQM12040taiRvSgqwUCPlN1qZAw6nYniYuY1hs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
+        "rev": "872c89e5a754a04058b4531e54897db5ca734100",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -67,11 +104,43 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1695360818,
+        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "act": "act",
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1693611461,
+        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1694478711,
+        "narHash": "sha256-zW/saV4diypxwP56b8l93Nw8fR7tXLbOFku2I+xYCxU=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "ddc704f3f62d3d3569ced794b534e8fd065c379c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695360818,
+        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1693471703,
+        "narHash": "sha256-0l03ZBL8P1P6z8MaSDS/MvuU8E75rVxe5eE1N6gxeTo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e52e76b70d5508f3cec70b882a29199f4d1ee85",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+# file: flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+      imports = [
+        inputs.haskell-flake.flakeModule
+      ];
+      perSystem = { self', system, lib, config, pkgs, ... }: {
+        haskellProjects.default = {
+          basePackages = pkgs.haskell.packages.ghc927;
+
+          settings = {
+            # TODO: whats going on here?
+            poly.check = false;
+          };
+
+          # What should haskell-flake add to flake outputs?
+          autoWire = [ "packages" "apps" "checks" ]; # Wire all but the devShell
+        };
+
+        devShells.default = pkgs.mkShell {
+          name = "open games devshell";
+          inputsFrom = [
+            config.haskellProjects.default.outputs.devShell
+          ];
+          nativeBuildInputs = with pkgs; [
+            # other development tools.
+          ];
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,9 @@
           autoWire = [ "packages" "apps" "checks" ];
         };
 
+        packages.default = self'.packages.open-games-hs;
+        apps.default = self'.apps.open-games-hs;
+
         devShells.default = pkgs.mkShell {
           name = "og devshell";
           inputsFrom = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,15 @@
-# file: flake.nix
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
+    act.url = "github:ethereum/act/52e99daf3121a4e6a6cb28255e862cf8e83cf4cd";
+    act.flake = false;
   };
 
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" ];
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
       imports = [
         inputs.haskell-flake.flakeModule
       ];
@@ -16,22 +17,27 @@
         haskellProjects.default = {
           basePackages = pkgs.haskell.packages.ghc927;
 
-          settings = {
-            # TODO: whats going on here?
-            poly.check = false;
+          packages = {
+            act.source = "${inputs.act}/src";
           };
 
-          # What should haskell-flake add to flake outputs?
-          autoWire = [ "packages" "apps" "checks" ]; # Wire all but the devShell
+          settings = {
+            act.extraTestToolDepends = [pkgs.z3];
+            poly = {
+              # TODO: what's going on here? why are these tests failing? where is this dep even coming from?
+              check = false;
+              broken = false;
+            };
+          };
+
+          # send everything but the devShell to the main flake outputs
+          autoWire = [ "packages" "apps" "checks" ];
         };
 
         devShells.default = pkgs.mkShell {
-          name = "open games devshell";
+          name = "og devshell";
           inputsFrom = [
             config.haskellProjects.default.outputs.devShell
-          ];
-          nativeBuildInputs = with pkgs; [
-            # other development tools.
           ];
         };
       };

--- a/open-games-hs.cabal
+++ b/open-games-hs.cabal
@@ -16,6 +16,7 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     README.md
+    amm.act
 
 library
   exposed-modules:


### PR DESCRIPTION
Adds a `flake.nix` that uses: https://github.com/srid/haskell-flake/. This is (imo) a pretty nice nix library that lets you write clean and declarative flakes for haskell projects. It does introduce some magic and additional abstraction which may or may not be worth it depending on your tastes. It does make it harder to do some more complex or lower level stuff (e.g. building fully static binaries will probably be hard or not work at all with this framework).

Apologies if this pr muddies the waters somewhat, I only realised that #20 existed once this was already written. In comparison to https://github.com/CyberCat-Institute/open-game-engine/pull/20, this is a fully `cabal` based flake, and completely removes all dependencies on stack. Dependencies are parsed out from the cabal file and then pulled from the `nixpkgs` haskell snapshot instead of the stackage lts snapshots. 

This pr only adds a flake, and so requires that anyone using it has the flakes features enabled in their nix instalation. Compatibility with the legacy nix commands could easily be provided using https://github.com/edolstra/flake-compat if desired.

There are two workflows:

- `nix build`: builds the project in a completely isolated nix based sandbox (this is essentially a highly restricted docker container)
- `nix develop`: prepares a development shell with all required dependencies preinstalled (including ghc / cabal / haskell language server). Once inside this shell, you can build with `cabal build` and enter a repl with `cabal repl`

Preparing the dev shell currently takes an outrageous amount of time (~1hr). This work needs to be done only once, and can be cached subsequently, but it's still obviously pretty painful. I suspect that this time is due to two things:

1. the usage of ghc-9.2.7 (afaik nixpkgs has much better caching for ghc-9.2.8)
2. the dependency on `poly` which is currently marked as broken in nixpkgs (it seems as though some of the test suite is failing, not sure if that is of concern or not). This would ideally be investigated further and fixed upstream.

I also added a `.envrc` file which provides a pretty nice workflow where it will automatically enter the development environment for this flake as soon as you cd into the repo root.